### PR TITLE
Fix for CVE-2020-25658

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,12 @@ Version 4.3 is almost a re-tagged release of version 4.0. It is the last to
 support Python 2.7. This is now made explicit in the `python_requires` argument
 in `setup.py`. Python 3.4 is not supported by this release.
 
+- Fix #165: CVE-2020-25658 - Bleichenbacher-style timing oracle in PKCS#1 v1.5
+  decryption code
+
+
+## Version 4.4 & 4.6 - released 2020-06-12
+
 Two security fixes have also been backported, so 4.3 = 4.0 + these two fixes.
 
 - Choose blinding factor relatively prime to N. Thanks Christian Heimes for pointing this out.

--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -30,6 +30,9 @@ to your users.
 
 import hashlib
 import os
+import sys
+import typing
+from hmac import compare_digest
 
 from rsa._compat import range
 from rsa import common, transform, core
@@ -237,17 +240,20 @@ def decrypt(crypto, priv_key):
     # Detect leading zeroes in the crypto. These are not reflected in the
     # encrypted value (as leading zeroes do not influence the value of an
     # integer). This fixes CVE-2020-13757.
-    if len(crypto) > blocksize:
-        raise DecryptionError('Decryption failed')
+    crypto_len_bad = len(crypto) > blocksize
 
     # If we can't find the cleartext marker, decryption failed.
-    if cleartext[0:2] != b'\x00\x02':
-        raise DecryptionError('Decryption failed')
+    cleartext_marker_bad = not compare_digest(cleartext[:2], b'\x00\x02')
 
     # Find the 00 separator between the padding and the message
     try:
         sep_idx = cleartext.index(b'\x00', 2)
     except ValueError:
+        sep_idx = -1
+    sep_idx_bad = sep_idx < 0
+
+    anything_bad = crypto_len_bad | cleartext_marker_bad | sep_idx_bad
+    if anything_bad:
         raise DecryptionError('Decryption failed')
 
     return cleartext[sep_idx + 1:]


### PR DESCRIPTION
Fix #165: CVE-2020-25658 - Bleichenbacher-style timing oracle

Use as many constant-time comparisons as practical in the `rsa.pkcs1.decrypt` function.

`cleartext.index(b'\x00', 2)` will still be non-constant-time. The alternative would be to iterate over all the data byte by byte in Python, which is several orders of magnitude slower. Given that a perfect constant-time implementation is very hard or even impossible to do in Python [1], I chose the more performant option here.

[1]: https://securitypitfalls.wordpress.com/2018/08/03/constant-time-compare-in-python/