### PR TITLE
Remove "Typing" because it breaks on Python2

### DIFF
--- a/rsa/pkcs1.py
+++ b/rsa/pkcs1.py
@@ -31,7 +31,6 @@ to your users.
 import hashlib
 import os
 import sys
-import typing
 from hmac import compare_digest
 
 from rsa._compat import range


### PR DESCRIPTION
As the title says, everything was happy, then bang, hit a wall in testing.
Tox is still happy without it, so I'm assuming we don't really care.